### PR TITLE
fix typo

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -5,8 +5,8 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "node sever.js",
-    "watch": "nodemon sever.js"
+    "start": "node server.js",
+    "watch": "nodemon server.js"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
Not sure if this is causing issues, but the npm scripts refer to "sever.js" instead of "server.js"